### PR TITLE
Add gitignore to ignore *.pyc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@
 /media/
 /navigation/
 .DS_Store
+
+# Python
+__pycache__
+.cache
+*.pyc
+
+


### PR DESCRIPTION
#### Description:

This pull-request configures .gitignore to ignore python `.pyc` files (compiled byte code)which can be different for different versions and implementation of Python. 

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC